### PR TITLE
Added StateChanger::Base#transitions method

### DIFF
--- a/lib/state_changer/base.rb
+++ b/lib/state_changer/base.rb
@@ -54,5 +54,17 @@ module StateChanger
 
       transition_container.get_by_full_key(transition_key).call(data.clone)
     end
+
+    def transitions(data)
+      state_container = self.class.state_container
+      transition_container = self.class.transition_container
+
+      states = state_container.keys
+        .map { |state| [state, state_container[state].call(data)] }
+        .select { |state| state.last }
+        .map(&:first)
+
+      transition_container.full_keys.select{ |i| states.include? i.last[:from].to_s }
+    end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -56,4 +56,22 @@ RSpec.describe StateChanger::Base do
       expect(machine.call(:switch, data)).to eq(light: 'green')
     end
   end
+
+  describe '#transitions' do
+    let(:machine) { TrafficLightStateMachine.new }
+
+    it 'returns list of allowed transitions' do
+      data = { light: 'red' }
+
+      expect(machine.transitions(data)).to eq([
+        ['switch', { from: :red, to: :green }]
+      ])
+    end
+
+    it 'returns empty list if no allowed transitions found for current state' do
+      data = { light: 'cyan' }
+
+      expect(machine.transitions(data)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Nice state machine!
It would be really nice to have an instance method that returns a list of allowed transitions for the current state.