### PR TITLE
Raising exceptions on wrong state or transition on call

### DIFF
--- a/lib/state_changer.rb
+++ b/lib/state_changer.rb
@@ -1,7 +1,9 @@
-require "state_changer/version"
-require "state_changer/base"
+# frozen_string_literal: true
+
+require 'state_changer/version'
+require 'state_changer/base'
 
 module StateChanger
-  class Error < StandardError; end
-  # Your code goes here...
+  class WrongStateError < StandardError; end
+  class WrongTransitionError < StandardError; end
 end

--- a/lib/state_changer/base.rb
+++ b/lib/state_changer/base.rb
@@ -1,4 +1,7 @@
-require "state_changer/container"
+# frozen_string_literal: true
+
+require 'state_changer/container'
+require 'forwardable'
 
 module StateChanger
   class Base
@@ -14,8 +17,6 @@ module StateChanger
       @state_container ||= StateChanger::Container.new
     end
 
-    # ............................................................
-
     def self.register_transition(event_name, path, &block)
       from_state = path.keys.first
       to_state = path.values.first
@@ -27,44 +28,39 @@ module StateChanger
       @transition_container ||= StateChanger::Container.new
     end
 
-    # ............................................................
-
     def call(event_name, data)
-      # 1. [DONE] get current state for data
-      # 1.2. [DONE] return error if zero matches for state
-      #
-      # 2. event_name + from_state = value from transition_container
-      # 3. execute transition
-      #
-      state_container = self.class.state_container
-      transition_container = self.class.transition_container
-
-      states = state_container.keys
-        .map { |state| [state, state_container[state].call(data)] }
-        .select { |state| state.last }
-        .map(&:first)
-
-      return 'Error' if states.empty?
+      states = select_states(data)
+      raise StateChanger::WrongStateError if states.empty?
 
       # TODO: use condition for getting more than one initial state for data
       state = states.first
-      transition_key = transition_container
-        .full_keys
-        .detect { |t| t.first == event_name.to_s && t.last[:from].to_s == state }
+      transition_key = transition_key(event_name, state)
+      raise StateChanger::WrongTransitionError if transition_key.nil?
 
       transition_container.get_by_full_key(transition_key).call(data.clone)
     end
 
     def transitions(data)
-      state_container = self.class.state_container
-      transition_container = self.class.transition_container
+      states = select_states(data)
+      transition_container.full_keys.select { |i| states.include? i.last[:from].to_s }
+    end
 
-      states = state_container.keys
-        .map { |state| [state, state_container[state].call(data)] }
-        .select { |state| state.last }
-        .map(&:first)
+    extend Forwardable
 
-      transition_container.full_keys.select{ |i| states.include? i.last[:from].to_s }
+    def_delegators 'self.class', :state?, :transition_container, :state_container
+
+    private :transition_container, :state_container
+
+    private
+
+    def transition_key(event_name, state)
+      transition_container.full_keys.detect do |t|
+        t.first == event_name.to_s && t.last[:from].to_s == state
+      end
+    end
+
+    def select_states(data)
+      state_container.keys.select { |state| state_container[state].call(data) }
     end
   end
 end

--- a/lib/state_changer/container.rb
+++ b/lib/state_changer/container.rb
@@ -28,10 +28,5 @@ module StateChanger
     def get_by_full_key(key)
       @container[key]
     end
-
-    # api private
-    def __container__
-      @container
-    end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -37,10 +37,16 @@ RSpec.describe StateChanger::Base do
   describe '#call' do
     let(:machine) { TrafficLightStateMachine.new }
 
-    it 'returns "Error" if data has invalid state' do
+    it 'raises WrongStateError if no corresponding state found' do
       data = { light: 'invalid' }
 
-      expect(machine.call(:switch, data)).to eq('Error')
+      expect { machine.call(:switch, data) }.to raise_error(StateChanger::WrongStateError)
+    end
+
+    it 'raises WrongTransitionError if no corresponding transition found' do
+      data = { light: 'red' }
+
+      expect { machine.call(:snitch, data) }.to raise_error(StateChanger::WrongTransitionError)
     end
 
     it 'returns new data mapped to next transition state' do


### PR DESCRIPTION
- Made some cleanup
- Added exceptions on wrong states/transitions on call (no exceptions on #state? or #transitions)