### PR TITLE
State helpers

### DIFF
--- a/lib/state_changer.rb
+++ b/lib/state_changer.rb
@@ -1,5 +1,8 @@
-require "state_changer/version"
-require "state_changer/base"
+# frozen_string_literal: true
+
+require 'state_changer/version'
+require 'state_changer/base'
+require 'state_changer/state_helpers'
 
 module StateChanger
   class Error < StandardError; end

--- a/lib/state_changer/state_helpers.rb
+++ b/lib/state_changer/state_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module StateChanger
+  module StateHelpers
+    def state(state_name, &block)
+      method_name = "#{state_name}?"
+      klass = self
+      helper_module = Module.new do |m|
+        m.define_method method_name do |data|
+          klass.state?(state_name, data)
+        end
+      end
+      include helper_module unless method_defined? method_name
+      extend helper_module unless singleton_class.method_defined? method_name
+      super
+    end
+  end
+end

--- a/spec/helpers/machine_with_helpers.rb
+++ b/spec/helpers/machine_with_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class ParentMachine < StateChanger::Base
+  def test?
+    "test"
+  end
+
+  def self.test?
+    "test"
+  end
+end
+
+class MachineWithHelpers < ParentMachine
+  extend StateChanger::StateHelpers
+
+  state(:first) { |c| !c.first.nil? }
+  state(:both) { |c| first?(c) && !c[1].nil? }
+  state(:test) { false }
+end

--- a/spec/state_helpers_spec.rb
+++ b/spec/state_helpers_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'helpers/machine_with_helpers'
+
+RSpec.describe StateChanger::StateHelpers do
+  describe '#<state_name>?' do
+    let(:machine) { MachineWithHelpers.new }
+
+    it 'is returns true if it is a current state' do
+      expect(machine.first?(['first'])).to be_truthy
+    end
+
+    it 'works inside state declaration' do
+      expect(machine.both?(%w[first second])).to be_truthy
+    end
+
+    it 'fails if inner state check fails' do
+      expect(machine.both?([nil, 'second'])).to be_falsy
+    end
+
+    it 'doesn\'t redefine existing methods' do
+      expect(machine.test?).to be_eql 'test'
+    end
+  end
+
+  describe '.<state_name>?' do
+    let(:machine) { MachineWithHelpers }
+
+    it 'is returns true if it is a current state' do
+      expect(machine.first?(['first'])).to be_truthy
+    end
+
+    it 'works inside state declaration' do
+      expect(machine.both?(%w[first second])).to be_truthy
+    end
+
+    it 'fails if inner state check fails' do
+      expect(machine.both?([nil, 'second'])).to be_falsy
+    end
+
+    it 'doesn\'t redefine existing methods' do
+      expect(machine.test?).to be_eql 'test'
+    end
+  end
+end


### PR DESCRIPTION
- It would be really nice to have helper methods to check states inside other states like
```ruby
class ColorChanger < StateChanger::Base
  extend StateChanger::StateHelpers
  state(:blue){|data| data[:color] == 'blue' }
  state(:cyan){|data| data[:color] == 'cyan' }
  state(:water_color){|data| blue?(data) || cyan?(data) }
end
```
- It is a simple solution for creating complex states without invoking longer version ```state?(:blue, data) || state?(:cyan, data)```